### PR TITLE
registration: show all registrations to admins

### DIFF
--- a/routes/registration.js
+++ b/routes/registration.js
@@ -58,11 +58,13 @@ function get_reg_fields(request, registration) {
 router.all('/', utils.require_feature("registration"));
 
 function show_list(req, res, next, show_private) {
+  var filter = {};
+  if(!show_private) {
+    filter = { is_public: true };
+  }
   Registration
     .findAll({
-      where: {
-        is_public: !show_private
-      },
+      where: filter,
       include: [User, RegistrationInfo]
     })
     .then(function(registrations) {

--- a/test/registration.js
+++ b/test/registration.js
@@ -116,11 +116,23 @@ describe('registration', function() {
     .end(done);
   });
 
+  it('should allow registration by admin', function(done) {
+    agent.post('/registration/register')
+    .send({'name': 'Admin'})
+    .send({'field_ircnick': 'adminnick'})
+    .send({'is_public': 'true'})
+    .expect(200)
+    .expect(/Thanks for registering/)
+    .end(done);
+  });
+
   it('should list all info for admin', function(done) {
     agent.get('/registration/admin/list')
     .expect(200)
     .expect(/TestUser A/)
     .expect(/testirc/)
+    .expect(/Admin/)
+    .expect(/adminnick/)
     .end(done)
   });
 


### PR DESCRIPTION
838f0bb introduced a bug where admins would only see registrations
not marked as public.
This patch fixes that by only adding the where filter if we are
not allowed to see all registrations.

Signed-off-by: Patrick Uiterwijk puiterwijk@redhat.com
