### PR TITLE
gnome: Force invalid amounts to 0.

### DIFF
--- a/public/javascripts/gnome-reg.js
+++ b/public/javascripts/gnome-reg.js
@@ -3,6 +3,10 @@
 $(function() {
 	$( '#reg-fee' ).change( function() {
 		amount =  parseFloat(this.value);
+		if (isNaN(amount)) {
+			$( "#reg-fee" ).val( 0 );
+			amount = 0;
+		}
 		$( '#reg-fee-slider' ).slider( "option", "value", amount );
 		$( '.perk' ).each(function() {
 			perk_amount = parseFloat($(this).attr('data-amount'));


### PR DESCRIPTION
Setting the slider to NaN breaks it, so just enforce 0 instead.
