### PR TITLE
Add openid to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "nodemailer": "*",
     "nodemailer-smtp-transport": "*",
     "country-data": "*",
+    "openid": "^2.0.0",
     "openid-client": "^ 1.5.3"
   },
   "devDependencies": {


### PR DESCRIPTION
`npm install` reported missing OpenID package. This PR adds OpenID as a dependency to `package.json`