### PR TITLE
Update link and put in login/logout buttons for testing purposes

### DIFF
--- a/app.js
+++ b/app.js
@@ -85,7 +85,7 @@ app.use(function(req, res, next) {
   res.locals.config = config;
   res.locals.req = { body: req.body,
                      query: req.query };
-  res.locals.development = config.env == 'development';
+  res.locals.development = config.env == 'development' || config.env == 'test';
 
   res.locals.login_buttons = routes_auth.buttons;
   res.locals.extra_js = [];

--- a/views/gnome/index/index.hbs
+++ b/views/gnome/index/index.hbs
@@ -51,6 +51,12 @@
          </div>
     </div>
 
+    {{#if development }}
+    <div>
+      <button id="loginBtn" {{{ login_buttons.login }}}>Development log in</button>
+    </div>
+    {{/if }}
+
     <div class="guadec-login">
       <p class="index-welcome">
         If you have trouble registering, please get in touch at
@@ -62,6 +68,11 @@
     </div>
 
 {{else}}
+    {{#if development }}
+    <div>
+      <button id="logoutBtn" {{{ login_buttons.logout }}}>Development log out</button>
+    </div>
+    {{/if }}
 
     Hi, {{name}}! Welcome to the GUADEC registration system.<br />
 

--- a/views/gnome/index/index.hbs
+++ b/views/gnome/index/index.hbs
@@ -128,8 +128,7 @@
 	Proposal submissions for the main conference days (Friday 6th to
 	Sunday 8th July) are currently open. You can find more information
 	about what we are looking for and other types of available slots on
-	the <a
-	href="https://2018.guadec.org/pages/proposals.html">main website</a>.
+	the <a href="https://2018.guadec.org/pages/submit-a-proposal.html">main website</a>.
       </p>
       <p>
 	There will be opportunities during the conference days (Friday 6th to


### PR DESCRIPTION
Functional change:
 * export "development" into template both in "development" and "test" environments

Other changes:
 * Show login/logout button in GNOME template if "development" is enabled
 * Fix link to CfP page on main website