### PR TITLE
Registration email address now a mailto link

### DIFF
--- a/views/gnome/index/index.hbs
+++ b/views/gnome/index/index.hbs
@@ -63,7 +63,7 @@
     <div class="guadec-login">
       <p class="index-welcome">
         If you have trouble registering, please get in touch at
-        guadec-organization@gnome.org.
+        <mailto href="guadec-organization@gnome.org?Subject=Registration%20problem">guadec&#x2011;organization@gnome.org</mailto>.
       </p>
     </div>
 


### PR DESCRIPTION
Also made the displayed address use a non-breaking hyphen.

Changes requested by Kat.

Signed-off-by: Lisa St.John <code@grimthorpe.org>